### PR TITLE
Improve lofi stream configuration and error handling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -197,6 +197,21 @@ p {
   transform: translateY(0);
 }
 
+.lofi-error {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  max-width: 320px;
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(231, 76, 60, 0.45);
+  border-radius: var(--border-radius);
+  background-color: rgba(231, 76, 60, 0.14);
+  color: #ffd6d1;
+  box-shadow: var(--shadow-md);
+  z-index: 200;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .app-header {

--- a/src/App.js
+++ b/src/App.js
@@ -11,11 +11,13 @@ import Mcse from './components/year2/cse/Mcse.js';
 import Wt from './components/year2/cse/Wt.js';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
+import { LOFI_STREAM_URL } from './config/lofi';
 
 function AppContent() {
     const [greeting, setGreeting] = useState('');
     const [icon, setIcon] = useState(null);
     const [isLofiPlaying, setLofiPlaying] = useState(false);
+    const [lofiError, setLofiError] = useState('');
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const location = useLocation();
 
@@ -39,7 +41,8 @@ function AppContent() {
     }, []);
 
     const toggleLofi = () => {
-        setLofiPlaying(!isLofiPlaying);
+        setLofiError('');
+        setLofiPlaying((isPlaying) => !isPlaying);
     };
 
     const toggleSidebar = () => {
@@ -91,10 +94,19 @@ function AppContent() {
             </div>
 
             {isLofiPlaying && (
-                <audio autoPlay loop>
-                    <source src="https://ec3.yesstreaming.net:3755/stream" type="audio/mp3" />
+                <audio
+                    autoPlay
+                    loop
+                    onError={() => setLofiError('Unable to load the lofi stream. Please try again later.')}
+                >
+                    <source src={LOFI_STREAM_URL} type="audio/mp3" />
                     Your browser does not support the audio element.
                 </audio>
+            )}
+            {lofiError && (
+                <p className="lofi-error" role="alert">
+                    {lofiError}
+                </p>
             )}
         </div>
     );

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,38 +1,37 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "./App";
+import { LOFI_STREAM_URL } from "./config/lofi";
 
-describe("App – Play Lofi toggle", () => {
-  it("shows 'Play Lofi' initially, then adds <audio> with stream when clicked, and removes it on pause", async () => {
+describe("App - Play Lofi toggle", () => {
+  it("uses the configured stream, reports load failures, and clears errors on pause", async () => {
     const user = userEvent.setup();
     const { container } = render(<App />);
 
-    // Initially: Play Lofi button is visible, no audio element
     const playBtn = screen.getByRole("button", { name: /play lofi/i });
     expect(playBtn).toBeInTheDocument();
     expect(container.querySelector("audio")).toBeNull();
 
-    // Click Play → button toggles to Pause, audio mounts with correct source
     await user.click(playBtn);
 
-    // Button now says Pause Lofi
     const pauseBtn = screen.getByRole("button", { name: /pause lofi/i });
     expect(pauseBtn).toBeInTheDocument();
 
-    // Audio element exists
     const audioEl = container.querySelector("audio");
     expect(audioEl).not.toBeNull();
 
-    // Verify the <source src="https://ec3.yesstreaming.net:3755/stream">
     const sourceEl = container.querySelector("audio source");
     expect(sourceEl).not.toBeNull();
-    // JSDOM resolves to absolute URLs, so we check it contains the expected host/path
-    expect(sourceEl.getAttribute("src")).toContain("ec3.yesstreaming.net:3755/stream");
+    expect(sourceEl.getAttribute("src")).toBe(LOFI_STREAM_URL);
 
-    // Click Pause → audio removed, button back to Play
+    fireEvent.error(audioEl);
+    expect(screen.getByRole("alert")).toHaveTextContent(/unable to load the lofi stream/i);
+
     await user.click(pauseBtn);
+
     expect(container.querySelector("audio")).toBeNull();
     expect(screen.getByRole("button", { name: /play lofi/i })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/config/lofi.js
+++ b/src/config/lofi.js
@@ -1,0 +1,3 @@
+const DEFAULT_LOFI_STREAM_URL = 'https://ec3.yesstreaming.net:3755/stream';
+
+export const LOFI_STREAM_URL = process.env.REACT_APP_LOFI_STREAM_URL || DEFAULT_LOFI_STREAM_URL;


### PR DESCRIPTION
## Summary
- move the lofi stream URL into a reusable config module with a REACT_APP_LOFI_STREAM_URL override
- show a visible error message when the audio stream fails to load
- clear the stream error when the user toggles the player again
- update the lofi player test to cover the configured URL and failure message

Fixes #4

## Verification
- npm test -- --watchAll=false src/App.test.jsx
- npm run build